### PR TITLE
Stop 'auto' value from being removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function spacedItems({ values, children = ['*']} = {}) {
   return function tailwindSpacedItems({ addUtilities, addUtilitiesaddComponents, e, prefix, config }) {
     let css = {}
     if (!values) {
-      values = config('margin')
+      values = Object.assign({}, config('margin'))
       delete values['auto']
     }
     


### PR DESCRIPTION
I've found an issue whilst using this plugin, in that I can no longer use `@apply` with the `mx-auto` class. It works with any other margin classes, just not with `auto`. It also breaks my layout as the `mx-auto` class is removed from my compiled CSS.

Here's a snippet of my Sass:

```sass
.faq-wrapper
  @apply w-full px-4 mx-auto
```

When attempting to compile Tailwind:

```
(83:3) `@apply` cannot be used with `.mx-auto` because `.mx-auto` either cannot be found, or its actual definition includes a pseudo-selector like :hover, :active, etc. If you're sure that `.mx-auto` exists, make sure that any `@import` statements are being properly processed *before* Tailwind CSS sees your CSS, as `@apply` can only be used for classes in the same CSS tree.
```

Having looks at index.js, the issue is with this line:

```js
delete values['auto']
```

It seems that removing auto from `values` it also removes it from `config`.

I've replaced this with the following which fixed the problem:

```diff
- values = config('margin')
+ values = Object.assign({}, config('margin'))
```